### PR TITLE
Added a way to configure a campaign start date.

### DIFF
--- a/sonar-connector/src/main/java/com/thepracticaldeveloper/devgame/modules/stats/service/ScoreCardServiceImpl.java
+++ b/sonar-connector/src/main/java/com/thepracticaldeveloper/devgame/modules/stats/service/ScoreCardServiceImpl.java
@@ -26,11 +26,14 @@ public class ScoreCardServiceImpl implements ScoreCardService {
     private static final Logger log = LoggerFactory.getLogger(ScoreCardServiceImpl.class);
 
     private final LocalDate legacyDate;
+    private final LocalDate campaignStartDate;
     private final ScoreCardMongoRepository cardRepository;
 
     public ScoreCardServiceImpl(@Value("${game.dates.legacy}") final String legacyDate,
+                                @Value("${game.dates.campaignStart}") final String campaignStartDate,
                                 final ScoreCardMongoRepository cardRepository) {
         this.legacyDate = LocalDate.parse(legacyDate);
+        this.campaignStartDate = LocalDate.parse(campaignStartDate);
         this.cardRepository = cardRepository;
         log.info("Legacy date is configured to {}", legacyDate);
     }
@@ -42,10 +45,14 @@ public class ScoreCardServiceImpl implements ScoreCardService {
                 collect(Collectors.toSet());
         log.trace("Fixed {} issues of {} issues assigned", fixedIssues.size(), issues.size());
 
-        // For the stats we only use those issues created before 'legacy date'
+        // For the stats we only use those issues created before 'legacy date'...
+        // ... and after 'campaign start date'.
         final Set<Issue> issuesFilteredByLegacyDate = fixedIssues.stream()
                 .filter(i -> IssueDateFormatter.format(i.getCreationDate())
-                        .isBefore(legacyDate)).collect(Collectors.toSet());
+                        .isBefore(legacyDate))
+                .filter(i -> IssueDateFormatter.format(i.getCloseDate())
+                        .isAfter(campaignStartDate))
+                .collect(Collectors.toSet());
 
         final long newResolvedIssues = issuesFilteredByLegacyDate.stream()
                 // checks that the issue has not been mapped already to any user

--- a/sonar-connector/src/main/resources/config/application.yml
+++ b/sonar-connector/src/main/resources/config/application.yml
@@ -9,6 +9,7 @@ game:
   dates:
     legacy: 2018-01-21
     earlyBird: 2018-01-30
+    campaignStart: 1970-01-01
   code:
 
 spring:


### PR DESCRIPTION
Added a way to configure a campaign start date.
The date is set through the game.dates.campaignStart property and will be used consider only resolved issues that were resolved after the date. The expected format is the same as the legacy date, yyyy-mm-dd.
When setting up a compose file, the date can be injected using the GAME_DATES_CAMPAIGNSTART environment variable.