### PR TITLE
How about add more Forked VM when run all tests in build

### DIFF
--- a/sonar-connector/pom.xml
+++ b/sonar-connector/pom.xml
@@ -62,7 +62,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.1</version>
                 <configuration>
-                    <forkCount>0</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
